### PR TITLE
Adding pill identification as an application

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Traditionally, they have defined metrics in a variety of ways, including pairwis
   - [Action localization](#action_loc)
   - [Adversarial attack](#adversarial)
   - [Text documentation](#text_documentation)
+  - [Pill identification](#pill_identification)
 - [Related works](#related)
   - [Neurips](#neurips)
   - [ICLR](#iclr)
@@ -328,11 +329,20 @@ Traditionally, they have defined metrics in a variety of ways, including pairwis
 
 - Metric Learning for Adversarial Robustness (Neurips 2019) [[Paper]](http://papers.nips.cc/paper/8339-metric-learning-for-adversarial-robustness.pdf)[[Tensorflow]](https://github.com/columbia/Metric_Learning_Adversarial_Robustness)
 
+
 <a name="text_documentation" />
 
 #### Text documentation
 
 - Fast(er) Reconstruction of Shredded Text Documents via Self-Supervised Deep Asymmetric Metric Learning (CVPR 2020) [[Paper]](https://arxiv.org/pdf/2003.10063.pdf)[[Code]](https://github.com/thiagopx/deeprec-cvpr20)
+
+
+<a name="pill_identification" />
+
+#### Pill identification
+
+- ePillID Dataset: A Low-Shot Fine-Grained Benchmark for Pill Identification (CVPR 2020) [[Paper]](https://arxiv.org/abs/2005.14288)[[Code]](https://github.com/usuyama/ePillID-benchmark)
+
 
 ---
 <a name="related" />


### PR DESCRIPTION
This repo is awesome! I'd like to propose to add "pill identification" to the application section.

Metric learning is heavily used for pill identification / pill image recognition. PillID is an active research area (e.g., multiple papers in CVPR 2020)